### PR TITLE
Dispatch signal

### DIFF
--- a/src/PnctlEmitter.php
+++ b/src/PnctlEmitter.php
@@ -22,7 +22,10 @@ class PnctlEmitter extends EventEmitter
      */
     public function on($signo, callable $listener)
     {
-        pcntl_signal($signo, array($this, 'emit'));
+        pcntl_signal($signo, function($signo) {
+            $this->emit($signo, array($signo));
+        });
+
         parent::on($signo, $listener);
     }
 


### PR DESCRIPTION
Signal will be available in the callback provided to the EventEmitter. This is useful if you want to create one handler for all signals :

``` php
$shutdown = function ($signal) {
     $this->eventEmitter->emit('shutdown', [$signal]);
};

$signalHandler->on(SIGINT, $shutdown);

$signalHandler->on(SIGTERM, $shutdown);
```
