### PR TITLE
Polyfill signature doesn't match core signature

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -1,7 +1,7 @@
 <?php
 
 if (!function_exists('pcntl_sigtimedwait')) {
-    function pcntl_sigtimedwait($signals, $siginfo, $sec, $nano)
+    function pcntl_sigtimedwait(array $signals, array &$siginfo = array(), $sec = 0, $nano = 0)
     {
         pcntl_signal_dispatch();
 


### PR DESCRIPTION
The function signature for the `pcntl_sigtimedwait()` polyfill doesn't match the signature [documented by PHP](http://php.net/manual/en/function.pcntl-sigtimedwait.php).
