### PR TITLE
Added latest EventLoop version and update PHP minimum required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         }
     ],
     "require": {
-        "php": ">=5.3",
+        "php": ">=5.4",
         "evenement/evenement" : "~2.0|~3.0",
-        "react/event-loop": "~0.4.0"
+        "react/event-loop": "~0.4.0|^0.5"
     },
     "autoload": {
         "psr-4": { "Gos\\Component\\PnctlEventLoopEmitter\\": "src/" },


### PR DESCRIPTION
Added  support to latest EventLoop version and update PHP minimum required version

> PHP 5.3 closures does not support `$this`